### PR TITLE
feat(parser): Add support for T-SQL binary constants

### DIFF
--- a/src/sqlfluff/dialects/dialect_tsql.py
+++ b/src/sqlfluff/dialects/dialect_tsql.py
@@ -390,10 +390,10 @@ tsql_dialect.add(
     # Here we add a special case for a DotSegment where we don't want to apply
     # LT01's respace rule.
     LeadingDotSegment=StringParser(".", SymbolSegment, type="leading_dot"),
-    HexadecimalLiteralSegment=RegexParser(
-        r"([xX]'([\da-fA-F][\da-fA-F])+'|0x[\da-fA-F]+)",
+    TsqlHexadecimalLiteralSegment=RegexParser(
+        r"(0x[\da-fA-F]*)",
         LiteralSegment,
-        type="numeric_literal",
+        type="binary_literal",
     ),
     PlusComparisonSegment=StringParser(
         "+", SymbolSegment, type="raw_comparison_operator"
@@ -455,6 +455,7 @@ tsql_dialect.replace(
     LiteralGrammar=ansi_dialect.get_grammar("LiteralGrammar")
     .copy(
         insert=[
+            Ref("TsqlHexadecimalLiteralSegment"),
             Ref("QuotedLiteralSegmentWithN"),
         ],
         before=Ref("NumericLiteralSegment"),

--- a/src/sqlfluff/dialects/dialect_tsql.py
+++ b/src/sqlfluff/dialects/dialect_tsql.py
@@ -2594,7 +2594,7 @@ class ColumnConstraintSegment(BaseSegment):
                             Ref("BareFunctionSegment"),
                             Ref("FunctionSegment"),
                             Ref("NextValueSequenceSegment"),
-                            Ref("HexadecimalLiteralSegment"),
+                            Ref("TsqlHexadecimalLiteralSegment"),
                         ),
                     ),
                 ),
@@ -3311,7 +3311,7 @@ class ReplicateFunctionContentsSegment(BaseSegment):
         Bracketed(
             OneOf(
                 Ref("ExpressionSegment"),
-                Ref("HexadecimalLiteralSegment"),
+                Ref("TsqlHexadecimalLiteralSegment"),
             ),
             Ref("CommaSegment"),
             Ref("ExpressionSegment"),
@@ -4730,7 +4730,7 @@ class SetContextInfoSegment(BaseSegment):
         "SET",
         "CONTEXT_INFO",
         OneOf(
-            Ref("HexadecimalLiteralSegment"),
+            Ref("TsqlHexadecimalLiteralSegment"),
             Ref("ParameterNameSegment"),
         ),
     )
@@ -6559,7 +6559,7 @@ class CreateLoginStatementSegment(BaseSegment):
         Sequence(
             "SID",
             Ref("EqualsSegment"),
-            Ref("HexadecimalLiteralSegment"),
+            Ref("TsqlHexadecimalLiteralSegment"),
         ),
         _default_database,
         _default_language,
@@ -6804,7 +6804,7 @@ class CreateUserStatementSegment(ansi.CreateUserStatementSegment):
         Sequence(
             "SID",
             Ref("EqualsSegment"),
-            Ref("HexadecimalLiteralSegment"),
+            Ref("TsqlHexadecimalLiteralSegment"),
         ),
         _allow_encrypted_value,
         Sequence(

--- a/test/fixtures/dialects/tsql/alter_table.yml
+++ b/test/fixtures/dialects/tsql/alter_table.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 5589a876d8cca343f15539310fb540c839f80b2f4ad9f2525b28d8910794430c
+_hash: c872d8a63c1573db96f5a52798517bc71ca0f9ddb648321cd0a5b677ac830e36
 file:
 - batch:
     statement:
@@ -1078,7 +1078,7 @@ file:
         - keyword: DEFAULT
         - bracketed:
             start_bracket: (
-            numeric_literal: '0x00'
+            binary_literal: '0x00'
             end_bracket: )
       - keyword: FOR
       - column_reference:

--- a/test/fixtures/dialects/tsql/binary_constant.sql
+++ b/test/fixtures/dialects/tsql/binary_constant.sql
@@ -1,0 +1,8 @@
+SELECT 0x0;
+SELECT 0x;
+SELECT 0xAE;
+SELECT 0x12Ef;
+SELECT 0x69048AEFDD010E;
+
+DECLARE @bin varbinary(1) = 0x0;
+SELECT CAST(0x0 as uniqueidentifier);

--- a/test/fixtures/dialects/tsql/binary_constant.yml
+++ b/test/fixtures/dialects/tsql/binary_constant.yml
@@ -1,0 +1,78 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: a11d4ea601181da712cb9b2bd24ec685cc5a737ca561ec82262371b0fcc17fc6
+file:
+  batch:
+  - statement:
+      select_statement:
+        select_clause:
+          keyword: SELECT
+          select_clause_element:
+            binary_literal: '0x0'
+        statement_terminator: ;
+  - statement:
+      select_statement:
+        select_clause:
+          keyword: SELECT
+          select_clause_element:
+            binary_literal: 0x
+        statement_terminator: ;
+  - statement:
+      select_statement:
+        select_clause:
+          keyword: SELECT
+          select_clause_element:
+            binary_literal: '0xAE'
+        statement_terminator: ;
+  - statement:
+      select_statement:
+        select_clause:
+          keyword: SELECT
+          select_clause_element:
+            binary_literal: '0x12Ef'
+        statement_terminator: ;
+  - statement:
+      select_statement:
+        select_clause:
+          keyword: SELECT
+          select_clause_element:
+            binary_literal: '0x69048AEFDD010E'
+        statement_terminator: ;
+  - statement:
+      declare_segment:
+        keyword: DECLARE
+        parameter: '@bin'
+        data_type:
+          data_type_identifier: varbinary
+          bracketed_arguments:
+            bracketed:
+              start_bracket: (
+              expression:
+                numeric_literal: '1'
+              end_bracket: )
+        comparison_operator:
+          raw_comparison_operator: '='
+        expression:
+          binary_literal: '0x0'
+        statement_terminator: ;
+  - statement:
+      select_statement:
+        select_clause:
+          keyword: SELECT
+          select_clause_element:
+            function:
+              function_name:
+                keyword: CAST
+              function_contents:
+                bracketed:
+                  start_bracket: (
+                  expression:
+                    binary_literal: '0x0'
+                  keyword: as
+                  data_type:
+                    data_type_identifier: uniqueidentifier
+                  end_bracket: )
+        statement_terminator: ;

--- a/test/fixtures/dialects/tsql/create_login.yml
+++ b/test/fixtures/dialects/tsql/create_login.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: a37f693c347dfe13b88ba1f444497a58bebd55e30bcc0d92604bb749d2adc2e4
+_hash: b404b7c655ceebbfe542297ff4905db3a7656831a7ebc123630de1b895c54241
 file:
   batch:
   - statement:
@@ -98,7 +98,7 @@ file:
       - keyword: SID
       - comparison_operator:
           raw_comparison_operator: '='
-      - numeric_literal: '0x241C11948AEEB749B0D22646DB1A19F2'
+      - binary_literal: '0x241C11948AEEB749B0D22646DB1A19F2'
   - statement_terminator: ;
   - statement:
       create_login_statement:

--- a/test/fixtures/dialects/tsql/create_user.yml
+++ b/test/fixtures/dialects/tsql/create_user.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: dec9cf9f72ec3b863a3155b45a150641d1f0dd342a7aece9c66dd6824d3d9c6b
+_hash: b8f2a76502789ba271e757077cd3ebcd06d90e10058a74159e9adcce3cded444
 file:
   batch:
   - statement:
@@ -170,5 +170,5 @@ file:
       - keyword: SID
       - comparison_operator:
           raw_comparison_operator: '='
-      - numeric_literal: '0x241C11948AEEB749B0D22646DB1A19F2'
+      - binary_literal: '0x241C11948AEEB749B0D22646DB1A19F2'
   - statement_terminator: ;

--- a/test/fixtures/dialects/tsql/replicate.yml
+++ b/test/fixtures/dialects/tsql/replicate.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: f9e4be1cf7752f39ca82f62cc70f98250c8695d27f87372723b9e0b4497aecd5
+_hash: 9017455bcacd7e4fe317cdd92c680bbfbf16c73e1c5569efb16c6eea2da88e12
 file:
   batch:
   - statement:
@@ -115,12 +115,13 @@ file:
                       keyword: REPLICATE
                     function_contents:
                       bracketed:
-                        start_bracket: (
-                        numeric_literal: '0x20'
-                        comma: ','
-                        expression:
+                      - start_bracket: (
+                      - expression:
+                          binary_literal: '0x20'
+                      - comma: ','
+                      - expression:
                           numeric_literal: '128'
-                        end_bracket: )
+                      - end_bracket: )
                 keyword: AS
                 data_type:
                   data_type_identifier: varbinary

--- a/test/fixtures/dialects/tsql/set_context_info.yml
+++ b/test/fixtures/dialects/tsql/set_context_info.yml
@@ -3,14 +3,14 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: ac90b1cbf372890a0cdd68884d7cb6035083f8dfde4433230a8afbae43d79000
+_hash: ff694f820401dc5abc363ef4563da9259aeb99b951bf13e09ffff8639c8efe55
 file:
   batch:
   - statement:
       set_context_info_statement:
       - keyword: SET
       - keyword: CONTEXT_INFO
-      - numeric_literal: '0x01010101'
+      - binary_literal: '0x01010101'
   - statement_terminator: ;
   - statement:
       declare_segment:
@@ -44,12 +44,13 @@ file:
                       keyword: REPLICATE
                     function_contents:
                       bracketed:
-                        start_bracket: (
-                        numeric_literal: '0x20'
-                        comma: ','
-                        expression:
+                      - start_bracket: (
+                      - expression:
+                          binary_literal: '0x20'
+                      - comma: ','
+                      - expression:
                           numeric_literal: '128'
-                        end_bracket: )
+                      - end_bracket: )
                 keyword: AS
                 data_type:
                   data_type_identifier: varbinary


### PR DESCRIPTION
This change adds support for T-SQL binary constants, such as `0x0` and the empty binary string `0x`.

A new `TsqlHexadecimalLiteralSegment` is introduced to handle the T-SQL specific binary constant syntax, which allows for zero or more hexadecimal characters. This segment is then added to the `LiteralGrammar` for the T-SQL dialect.

A comprehensive set of test cases has been added to verify that binary constants are parsed correctly in various contexts, including `SELECT` statements, variable declarations, and function arguments.


<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->


### Are there any other side effects of this change that we should be aware of?


### Pull Request checklist
- [ ] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
